### PR TITLE
Feature/javafx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,20 @@ RUN cd /tmp \
 	&& pip install mkdocs-cinder
 
 
+# install jetbrains-JDK with functional javafx
+## for headless gtk
+ENV DISPLAY :0
+## needed for javafx
+RUN apt-get install --yes libgtk2.0-0 libxslt1.1
+## install jetbrains-JDK
+RUN export JBJDK_VERSION="jbrsdk-8u202-linux-x64-b1483.37" \
+    && wget --progress=dot:giga -O /tmp/${JBJDK_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JBJDK_VERSION}.tar.gz \
+	&& mkdir /usr/lib/jvm/${JBJDK_VERSION} \
+	&& tar xzf /tmp/${JBJDK_VERSION}.tar.gz --directory /usr/lib/jvm/${JBJDK_VERSION}
+## echo "Installed jetbrains-jdk version `cat /usr/lib/jvm/${JBJDK_VERSION}/release | grep JAVA_VERSION`" \
+## echo "Run export JAVA_HOME=\"/usr/lib/jvm/${JBJDK_VERSION}/\" PATH=\"/usr/lib/jvm/${JBJDK_VERSION}/bin:$PATH\" to select this jdk"
+
+
 RUN chmod +x /usr/bin/*
 
 COPY ./.gradle/init.d/* /root/.gradle/init.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,9 +95,10 @@ ENV DISPLAY :0
 RUN apt-get install --yes libgtk2.0-0 libxslt1.1
 ## install jetbrains-JDK
 RUN export JBJDK_VERSION="jbrsdk-8u202-linux-x64-b1483.37" \
-    && wget --progress=dot:giga -O /tmp/${JBJDK_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JBJDK_VERSION}.tar.gz \
+	&& wget --progress=dot:giga -O /tmp/${JBJDK_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JBJDK_VERSION}.tar.gz \
 	&& mkdir /usr/lib/jvm/${JBJDK_VERSION} \
-	&& tar xzf /tmp/${JBJDK_VERSION}.tar.gz --directory /usr/lib/jvm/${JBJDK_VERSION}
+	&& tar xzf /tmp/${JBJDK_VERSION}.tar.gz --directory /usr/lib/jvm/${JBJDK_VERSION} \
+	&& rm /tmp/${JBJDK_VERSION}.tar.gz
 ## echo "Installed jetbrains-jdk version `cat /usr/lib/jvm/${JBJDK_VERSION}/release | grep JAVA_VERSION`" \
 ## echo "Run export JAVA_HOME=\"/usr/lib/jvm/${JBJDK_VERSION}/\" PATH=\"/usr/lib/jvm/${JBJDK_VERSION}/bin:$PATH\" to select this jdk"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -y \
 	&& update-java-alternatives -s java-1.8.0-openjdk-amd64
 
 RUN cd /tmp && \
-	wget https://github.com/aktau/github-release/releases/download/v0.6.2/linux-amd64-github-release.tar.bz2 && \
+	wget --progress=dot:mega https://github.com/aktau/github-release/releases/download/v0.6.2/linux-amd64-github-release.tar.bz2 && \
 	tar -xjvf linux-amd64-github-release.tar.bz2 && \
 	mv bin/linux/amd64/github-release /usr/bin/ && \
 	rm -rf bin/
@@ -41,13 +41,13 @@ RUN \
 	cmake_major_minor=3.10 && \
 	cmake=cmake-${cmake_major_minor}.2-Linux-x86_64 && \
 	cd /tmp && \
-	wget https://cmake.org/files/v${cmake_major_minor}/${cmake}.tar.gz && \
+	wget --progress=dot:mega https://cmake.org/files/v${cmake_major_minor}/${cmake}.tar.gz && \
 	tar -xzvf ${cmake}.tar.gz && \
 	cp -R ${cmake}/bin ${cmake}/share /usr && \
 	rm -rf ${cmake} ${cmake}.tar.gz
 
 RUN mkdir /buildAgent && cd /buildAgent && \
-	wget https://build.mbeddr.com/update/buildAgent.zip && \
+	wget --progress=dot:mega https://build.mbeddr.com/update/buildAgent.zip && \
 	unzip buildAgent.zip && \
 	chmod +x /buildAgent/bin/agent.sh
 ADD ./buildAgent.properties /buildAgent/conf/buildAgent.properties
@@ -63,7 +63,7 @@ COPY ./bin/* /usr/bin/
 RUN \
 	cppcheck_version=1.77 && \
 	cd /tmp && \
-	wget -O cppcheck-${cppcheck_version}.tar.gz https://github.com/danmar/cppcheck/archive/${cppcheck_version}.tar.gz && \
+	wget --progress=dot:mega -O cppcheck-${cppcheck_version}.tar.gz https://github.com/danmar/cppcheck/archive/${cppcheck_version}.tar.gz && \
 	tar -zxf cppcheck-${cppcheck_version}.tar.gz && \
 	apt-get -y install libpcre3-dev && \
 	(cd cppcheck-${cppcheck_version} && make install -j`nproc` SRCDIR=build CFGDIR=/usr/share/cppcheck/cfg HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function") && \
@@ -73,7 +73,7 @@ RUN \
 RUN \
 	z3_version=4.7.1 && \
 	cd /tmp && \
-	wget -O z3.zip https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/z3-${z3_version}-x64-ubuntu-16.04.zip && \
+	wget --progress=dot:mega -O z3.zip https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/z3-${z3_version}-x64-ubuntu-16.04.zip && \
 	unzip z3.zip && \
 	mv z3-${z3_version}-x64-ubuntu-16.04/bin/z3 /usr/bin/ && \
 	mv z3-${z3_version}-x64-ubuntu-16.04/bin/libz3.so /usr/bin/ && \
@@ -81,7 +81,7 @@ RUN \
 	rm -rf /tmp/z3-${z3_version}-x64-ubuntu-16.04 z3.zip
 
 RUN cd /tmp \
-	&& wget https://bootstrap.pypa.io/get-pip.py \
+	&& wget --progress=dot:mega https://bootstrap.pypa.io/get-pip.py \
 	&& python get-pip.py \
 	&& rm get-pip.py \
 	&& pip install mkdocs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,8 @@ ENV DISPLAY :0
 ## needed for javafx
 RUN apt-get install --yes libgtk2.0-0 libxslt1.1
 ## install jetbrains-JDK
-RUN export JBJDK_VERSION="jbrsdk-8u202-linux-x64-b1483.37" \
-	&& wget --progress=dot:giga -O /tmp/${JBJDK_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JBJDK_VERSION}.tar.gz \
+ENV JBJDK_VERSION jbrsdk-8u202-linux-x64-b1483.37
+RUN wget --progress=dot:giga -O /tmp/${JBJDK_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JBJDK_VERSION}.tar.gz \
 	&& mkdir /usr/lib/jvm/${JBJDK_VERSION} \
 	&& tar xzf /tmp/${JBJDK_VERSION}.tar.gz --directory /usr/lib/jvm/${JBJDK_VERSION} \
 	&& rm /tmp/${JBJDK_VERSION}.tar.gz


### PR DESCRIPTION
# Motivation
- since the current teamcity build workers do not have javafx properly setup any ci test that involved a javafx-editor runs into a deadlock
- The jetbrains-jdk already brings javafx
- For some usecases, some further native libraries are needed

# Usage

The default JDK did not change. If a project wants to use the jetbrains-jdk, it can opt into that by setting env vars.

Set these env vars to use the jetbrains jdk in your shell with current version being: `jbrsdk-8u202-linux-x64-b1483.37`:

```
export JAVA_HOME="/usr/lib/jvm/jbrsdk-8u202-linux-x64-b1483.37/" PATH="/usr/lib/jvm/jbrsdk-8u202-linux-x64-b1483.37/bin:$PATH"
```

# Todos
- [x] download fixed version of jetbrains jdk from jfrog and extract it into `/usr/lib/jvm/<version>/`
- [x] install libgtk2.0-0 and libxslt1.1 to get the missing shared objects
- [x] set `DISPLAY=:0` so that headless X11 knows where the display host is
- [x] shorten wget progress bars to ease scrolling logs
- [x] test if javafx cells are working in editor tests now
- [x] test with Security Analyst 
- [ ] test with some other project (although no interference is expected)

