### PR TITLE
JetBrains JDK 8 and 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,20 +88,31 @@ RUN cd /tmp \
 	&& pip install mkdocs-cinder
 
 
-# install jetbrains-JDK with functional javafx
+# install JetBrains JDK 8 with functional javafx
 ## for headless gtk
 ENV DISPLAY :0
 ## needed for javafx
 RUN apt-get install --yes libgtk2.0-0 libxslt1.1
-## install jetbrains-JDK
-ENV JBJDK_VERSION jbrsdk-8u202-linux-x64-b1483.37
-RUN wget --progress=dot:giga -O /tmp/${JBJDK_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JBJDK_VERSION}.tar.gz \
-	&& mkdir /usr/lib/jvm/${JBJDK_VERSION} \
-	&& tar xzf /tmp/${JBJDK_VERSION}.tar.gz --directory /usr/lib/jvm/${JBJDK_VERSION} \
-	&& rm /tmp/${JBJDK_VERSION}.tar.gz
-## echo "Installed jetbrains-jdk version `cat /usr/lib/jvm/${JBJDK_VERSION}/release | grep JAVA_VERSION`" \
-## echo "Run export JAVA_HOME=\"/usr/lib/jvm/${JBJDK_VERSION}/\" PATH=\"/usr/lib/jvm/${JBJDK_VERSION}/bin:$PATH\" to select this jdk"
 
+## install JetBrains JDK 8
+ENV JB_JAVA8_VERSION jbrsdk-8u202-linux-x64-b1483.37
+RUN wget --progress=dot:giga -O /tmp/${JB_JAVA8_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JB_JAVA8_VERSION}.tar.gz \
+	&& mkdir /usr/lib/jvm/${JB_JAVA8_VERSION} \
+	&& tar xzf /tmp/${JB_JAVA8_VERSION}.tar.gz --directory /usr/lib/jvm/${JB_JAVA8_VERSION} \
+	&& rm /tmp/${JB_JAVA8_VERSION}.tar.gz
+ENV JB_JAVA8_HOME /usr/lib/jvm/${JB_JAVA8_VERSION}
+## echo "Installed JetBrains JDK 8 version `cat /usr/lib/jvm/${JB_JAVA8_VERSION}/release | grep JAVA_VERSION`" \
+## echo "Run export JAVA_HOME=\"/usr/lib/jvm/${JB_JAVA8_VERSION}/\" PATH=\"/usr/lib/jvm/${JB_JAVA8_VERSION}/bin:$PATH\" to select this jdk"
+
+## install JetBrains JDK 11
+ENV JB_JAVA11_VERSION jbrsdk-11_0_3-linux-x64-b304.39
+RUN wget --progress=dot:giga -O /tmp/${JB_JAVA11_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=${JB_JAVA11_VERSION}.tar.gz \
+	&& tar xzf /tmp/${JB_JAVA11_VERSION}.tar.gz --directory /tmp \
+	&& mv /tmp/jbrsdk /usr/lib/jvm/${JB_JAVA11_VERSION} \
+	&& rm /tmp/${JB_JAVA11_VERSION}.tar.gz
+ENV JB_JAVA11_HOME /usr/lib/jvm/${JB_JAVA11_VERSION}
+## echo "Installed JetBrains JDK 8 version `cat /usr/lib/jvm/${JB_JAVA11_VERSION}/release | grep JAVA_VERSION`" \
+## echo "Run export JAVA_HOME=\"/usr/lib/jvm/${JB_JAVA11_VERSION}/\" PATH=\"/usr/lib/jvm/${JB_JAVA11_VERSION}/bin:$PATH\" to select this jdk"
 
 RUN chmod +x /usr/bin/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,20 @@ RUN cd /tmp \
 	&& pip install mkdocs-cinder
 
 
+# install jetbrains-JDK with functional javafx
+## for headless gtk
+ENV DISPLAY :0
+## needed for javafx
+RUN apt-get install --yes libgtk2.0-0 libxslt1.1
+## install jetbrains-JDK
+RUN export JBJDK_VERSION="jbrsdk-8u202-linux-x64-b1483.37" \
+    && wget --progress=dot:giga -O /tmp/${JBJDK_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JBJDK_VERSION}.tar.gz \
+	&& mkdir /usr/lib/jvm/${JBJDK_VERSION} \
+	&& tar xzf /tmp/${JBJDK_VERSION}.tar.gz --directory /usr/lib/jvm/${JBJDK_VERSION}
+## echo "Installed jetbrains-jdk version `cat /usr/lib/jvm/${JBJDK_VERSION}/release | grep JAVA_VERSION`" \
+## echo "Run export JAVA_HOME=\"/usr/lib/jvm/${JBJDK_VERSION}/\" PATH=\"/usr/lib/jvm/${JBJDK_VERSION}/bin:$PATH\" to select this jdk"
+
+
 RUN chmod +x /usr/bin/*
 
 COPY ./.gradle/init.d/* /root/.gradle/init.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,8 @@ ENV DISPLAY :0
 ## needed for javafx
 RUN apt-get install --yes libgtk2.0-0 libxslt1.1
 
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
 ## install JetBrains JDK 8
 ENV JB_JAVA8_VERSION jbrsdk-8u202-linux-x64-b1483.37
 RUN wget --progress=dot:giga -O /tmp/${JB_JAVA8_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JB_JAVA8_VERSION}.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,9 +95,10 @@ ENV DISPLAY :0
 RUN apt-get install --yes libgtk2.0-0 libxslt1.1
 ## install jetbrains-JDK
 RUN export JBJDK_VERSION="jbrsdk-8u202-linux-x64-b1483.37" \
-    && wget --progress=dot:giga -O /tmp/${JBJDK_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JBJDK_VERSION}.tar.gz \
+	&& wget --progress=dot:giga -O /tmp/${JBJDK_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JBJDK_VERSION}.tar.gz \
 	&& mkdir /usr/lib/jvm/${JBJDK_VERSION} \
-	&& tar xzf /tmp/${JBJDK_VERSION}.tar.gz --directory /usr/lib/jvm/${JBJDK_VERSION}
+	&& tar xzf /tmp/${JBJDK_VERSION}.tar.gz --directory /usr/lib/jvm/${JBJDK_VERSION} \
+	&& rm /tmp/${JBJDK_VERSION}.tar.gz
 ## echo "Installed jetbrains-jdk version `cat /usr/lib/jvm/${JBJDK_VERSION}/release | grep JAVA_VERSION`" \
 ## echo "Run export JAVA_HOME=\"/usr/lib/jvm/${JBJDK_VERSION}/\" PATH=\"/usr/lib/jvm/${JBJDK_VERSION}/bin:$PATH\" to select this jdk"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -y \
 	&& update-java-alternatives -s java-1.8.0-openjdk-amd64
 
 RUN cd /tmp && \
-	wget https://github.com/aktau/github-release/releases/download/v0.6.2/linux-amd64-github-release.tar.bz2 && \
+	wget --progress=dot:mega https://github.com/aktau/github-release/releases/download/v0.6.2/linux-amd64-github-release.tar.bz2 && \
 	tar -xjvf linux-amd64-github-release.tar.bz2 && \
 	mv bin/linux/amd64/github-release /usr/bin/ && \
 	rm -rf bin/
@@ -41,13 +41,13 @@ RUN \
 	cmake_major_minor=3.10 && \
 	cmake=cmake-${cmake_major_minor}.2-Linux-x86_64 && \
 	cd /tmp && \
-	wget https://cmake.org/files/v${cmake_major_minor}/${cmake}.tar.gz && \
+	wget --progress=dot:mega https://cmake.org/files/v${cmake_major_minor}/${cmake}.tar.gz && \
 	tar -xzvf ${cmake}.tar.gz && \
 	cp -R ${cmake}/bin ${cmake}/share /usr && \
 	rm -rf ${cmake} ${cmake}.tar.gz
 
 RUN mkdir /buildAgent && cd /buildAgent && \
-	wget https://build.mbeddr.com/update/buildAgent.zip && \
+	wget --progress=dot:mega https://build.mbeddr.com/update/buildAgent.zip && \
 	unzip buildAgent.zip && \
 	chmod +x /buildAgent/bin/agent.sh
 ADD ./buildAgent.properties /buildAgent/conf/buildAgent.properties
@@ -63,7 +63,7 @@ COPY ./bin/* /usr/bin/
 RUN \
 	cppcheck_version=1.77 && \
 	cd /tmp && \
-	wget -O cppcheck-${cppcheck_version}.tar.gz https://github.com/danmar/cppcheck/archive/${cppcheck_version}.tar.gz && \
+	wget --progress=dot:mega -O cppcheck-${cppcheck_version}.tar.gz https://github.com/danmar/cppcheck/archive/${cppcheck_version}.tar.gz && \
 	tar -zxf cppcheck-${cppcheck_version}.tar.gz && \
 	apt-get -y install libpcre3-dev && \
 	(cd cppcheck-${cppcheck_version} && make install -j`nproc` SRCDIR=build CFGDIR=/usr/share/cppcheck/cfg HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function") && \
@@ -73,7 +73,7 @@ RUN \
 RUN \
 	z3_version=4.7.1 && \
 	cd /tmp && \
-	wget -O z3.zip https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/z3-${z3_version}-x64-ubuntu-16.04.zip && \
+	wget --progress=dot:mega -O z3.zip https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/z3-${z3_version}-x64-ubuntu-16.04.zip && \
 	unzip z3.zip && \
 	mv z3-${z3_version}-x64-ubuntu-16.04/bin/z3 /usr/bin/ && \
 	mv z3-${z3_version}-x64-ubuntu-16.04/bin/libz3.so /usr/bin/ && \
@@ -81,7 +81,7 @@ RUN \
 	rm -rf /tmp/z3-${z3_version}-x64-ubuntu-16.04 z3.zip
 
 RUN cd /tmp \
-	&& wget https://bootstrap.pypa.io/get-pip.py \
+	&& wget --progress=dot:mega https://bootstrap.pypa.io/get-pip.py \
 	&& python get-pip.py \
 	&& rm get-pip.py \
 	&& pip install mkdocs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,8 @@ ENV DISPLAY :0
 ## needed for javafx
 RUN apt-get install --yes libgtk2.0-0 libxslt1.1
 ## install jetbrains-JDK
-RUN export JBJDK_VERSION="jbrsdk-8u202-linux-x64-b1483.37" \
-	&& wget --progress=dot:giga -O /tmp/${JBJDK_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JBJDK_VERSION}.tar.gz \
+ENV JBJDK_VERSION jbrsdk-8u202-linux-x64-b1483.37
+RUN wget --progress=dot:giga -O /tmp/${JBJDK_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=${JBJDK_VERSION}.tar.gz \
 	&& mkdir /usr/lib/jvm/${JBJDK_VERSION} \
 	&& tar xzf /tmp/${JBJDK_VERSION}.tar.gz --directory /usr/lib/jvm/${JBJDK_VERSION} \
 	&& rm /tmp/${JBJDK_VERSION}.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#mbeddr.build.docker
+# mbeddr.build.docker
 
 This repository contains the source code for the docker images used to build mbeddr and other MPS based projects.
 It is basically a teamcity build agent with some additional packages for compiling.
@@ -20,3 +20,15 @@ docker run --name buildAgent1 -d --restart=always --storage-opt size=50G -e AGEN
 
 The agent gets its name from the environment variable `AGENT_NAME`. This name will showup in the teamcity web ui. If you don't set
 the name you will endup with a agent called `placeholder`.
+
+# JDK selection
+
+By default, the openjdk 8 will be used. Set env vars `PATH` and `JAVA_HOME` to select a jetbrains jdk:
+
+```
+# for jetbrains java 8
+export JAVA_HOME="/usr/lib/jvm/${JB_JAVA8_VERSION}/" PATH="/usr/lib/jvm/${JB_JAVA8_VERSION}/bin:$PATH"
+
+# for jetbrains java 11
+export JAVA_HOME="/usr/lib/jvm/${JB_JAVA11_VERSION}/" PATH="/usr/lib/jvm/${JB_JAVA11_VERSION}/bin:$PATH"
+```

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ By default, the openjdk 8 will be used. Set env vars `PATH` and `JAVA_HOME` to s
 
 ```
 # for jetbrains java 8
-export JAVA_HOME="/usr/lib/jvm/${JB_JAVA8_VERSION}/" PATH="/usr/lib/jvm/${JB_JAVA8_VERSION}/bin:$PATH"
+export JAVA_HOME=$JB_JAVA8_HOME PATH="${JB_JAVA8_HOME}/bin:$PATH"
 
 # for jetbrains java 11
-export JAVA_HOME="/usr/lib/jvm/${JB_JAVA11_VERSION}/" PATH="/usr/lib/jvm/${JB_JAVA11_VERSION}/bin:$PATH"
+export JAVA_HOME=$JB_JAVA11_HOME PATH="${JB_JAVA11_HOME}/bin:$PATH"
 ```

--- a/README.md
+++ b/README.md
@@ -1,34 +1,38 @@
 # mbeddr.build.docker
 
-This repository contains the source code for the docker images used to build mbeddr and other MPS based projects.
-It is basically a teamcity build agent with some additional packages for compiling.
+This repository contains the source code for the Docker images used to build mbeddr and other MPS-based projects. It is
+basically a TeamCity build agent with some additional packages for compiling the generated Java and C code.
 
-Using the image is fairly simple:
+Using the image to run a TeamCity agent is fairly simple:
 
 ```
 docker pull mbeddr/mbeddr.build.docker
 docker run --name buildAgent1 -d --restart=always -e AGENT_NAME=awesomeAgent mbeddr/mbeddr.build.docker
 ```
 
-If you run docker on a storage backend that supports size limits for the volumes it makes sense to limit the available disk space for the agent:
+If you run Docker on a storage backend that supports size limits for the volumes it makes sense to limit the available
+disk space for the agent:
 
 ```
 docker pull mbeddr/mbeddr.build.docker
 docker run --name buildAgent1 -d --restart=always --storage-opt size=50G -e AGENT_NAME=awesomeAgent mbeddr/mbeddr.build.docker
 ```
 
+The agent gets its name from the environment variable `AGENT_NAME`. This name will show up in the teamcity web ui. If
+you don't set the name you will endup with a agent called `placeholder`.
 
-The agent gets its name from the environment variable `AGENT_NAME`. This name will showup in the teamcity web ui. If you don't set
-the name you will endup with a agent called `placeholder`.
+# Installed JDKs
 
-# JDK selection
+These JDKs are installed:
+- OpenJDK 8 at $JAVA_HOME (default, used by the TeamCity agent)
+- JetBrains Runtime (JDK) 8 at $JB_JAVA8_HOME
+- JetBrains Runtime (JDK) 11 at $JB_JAVA11_HOME
 
-By default, the openjdk 8 will be used. Set env vars `PATH` and `JAVA_HOME` to select a jetbrains jdk:
+MPS requires JDK 8 up to version 2019.1 but requires JDK 11 since version 2019.2.
 
-```
-# for jetbrains java 8
-export JAVA_HOME=$JB_JAVA8_HOME PATH="${JB_JAVA8_HOME}/bin:$PATH"
+You can configure a build step in TeamCity to use a specific non-default JDK.
 
-# for jetbrains java 11
-export JAVA_HOME=$JB_JAVA11_HOME PATH="${JB_JAVA11_HOME}/bin:$PATH"
-```
+Builds using a recent version of [`mps-gradle-plugin`](https://github.com/mbeddr/mps-gradle-plugin/) can specify the JVM
+to use for a particular invocation of MPS by setting the `executable` parameter (see the [documentation of the
+`RunAntScript` task](https://github.com/mbeddr/mps-gradle-plugin/#runantscript)). This makes it possible to build
+different branches of the same project with different JDKs without having to duplicate build configurations.

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,5 @@ fi
 
 export CONFIG_FILE=/buildAgent/conf/buildAgent.properties
 export PID_FILE=/run/tc-agent.pid
-export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-export DISPLAY=:0.0
 
 /buildAgent/bin/agent.sh run


### PR DESCRIPTION
This is based on #5, adds JetBrains JDK 11 (the exact version that's used in MPS 2019.2.1) and exports the paths to JDK home directories.