### PR TITLE
Add NSIS to agent docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
 	libwww-perl \
 	libxerces-c-dev \
 	make \
+	nsis \
 	g++-4.8-multilib \
 	libstdc++6:i386 libgcc1:i386 zlib1g:i386 libncurses5:i386 \
 	openjdk-8-jdk=8u162-b12-1 openjdk-8-jre=8u162-b12-1 openjdk-8-jdk-headless=8u162-b12-1 openjdk-8-jre-headless=8u162-b12-1 \


### PR DESCRIPTION
In order to create NSIS Windows installer packages in our CI pipeline, we need to include NSIS in our build agent image.