### PR TITLE
Update to jbrsdk 11 0 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,8 +108,8 @@ ENV JB_JAVA8_HOME /usr/lib/jvm/${JB_JAVA8_VERSION}
 ## echo "Run export JAVA_HOME=\"/usr/lib/jvm/${JB_JAVA8_VERSION}/\" PATH=\"/usr/lib/jvm/${JB_JAVA8_VERSION}/bin:$PATH\" to select this jdk"
 
 ## install JetBrains JDK 11
-ENV JB_JAVA11_VERSION jbrsdk-11_0_3-linux-x64-b304.39
-RUN wget --progress=dot:giga -O /tmp/${JB_JAVA11_VERSION}.tar.gz https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=${JB_JAVA11_VERSION}.tar.gz \
+ENV JB_JAVA11_VERSION 11_0_9-b944.49
+RUN wget --progress=dot:giga -O /tmp/${JB_JAVA11_VERSION}.tar.gz https://projects.itemis.de/nexus/service/local/repositories/mbeddr/content/com/jetbrains/jdk/jbrsdk/${JB_JAVA11_VERSION}/jbrsdk-${JB_JAVA11_VERSION}-linux-x64.tgz \
 	&& tar xzf /tmp/${JB_JAVA11_VERSION}.tar.gz --directory /tmp \
 	&& mv /tmp/jbrsdk /usr/lib/jvm/${JB_JAVA11_VERSION} \
 	&& rm /tmp/${JB_JAVA11_VERSION}.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ ENV JB_JAVA8_HOME /usr/lib/jvm/${JB_JAVA8_VERSION}
 
 ## install JetBrains JDK 11
 ENV JB_JAVA11_VERSION 11_0_9-b944.49
-RUN wget --progress=dot:giga -O /tmp/${JB_JAVA11_VERSION}.tar.gz https://projects.itemis.de/nexus/service/local/repositories/mbeddr/content/com/jetbrains/jdk/jbrsdk/${JB_JAVA11_VERSION}/jbrsdk-${JB_JAVA11_VERSION}-linux-x64.tgz \
+RUN wget --progress=dot:giga -O /tmp/${JB_JAVA11_VERSION}.tar.gz https://projects.itemis.de/nexus/content/repositories/mbeddr/com/jetbrains/jdk/jbrsdk/${JB_JAVA11_VERSION}/jbrsdk-${JB_JAVA11_VERSION}-linux-x64.tgz \
 	&& tar xzf /tmp/${JB_JAVA11_VERSION}.tar.gz --directory /tmp \
 	&& mv /tmp/jbrsdk /usr/lib/jvm/${JB_JAVA11_VERSION} \
 	&& rm /tmp/${JB_JAVA11_VERSION}.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN \
 	rm -rf /tmp/z3-${z3_version}-x64-ubuntu-16.04 z3.zip
 
 RUN cd /tmp \
-	&& wget --progress=dot:mega https://bootstrap.pypa.io/get-pip.py \
+	&& wget --progress=dot:mega https://bootstrap.pypa.io/2.7/get-pip.py \
 	&& python get-pip.py \
 	&& rm get-pip.py \
 	&& pip install mkdocs \


### PR DESCRIPTION
In YSA, we think, we're experiencing an instance of https://bugs.openjdk.java.net/browse/JDK-8220448 in our CLI builds. This is an issue with jdk 11.0.3 and was fixed with 11.0.4

# What changed
- pin pip to version that works with python 2.7 (it broke the Dockerfile) to fix the build
- update jb java 11 sdk to 11_0_9-b944.49 to mitigate https://bugs.openjdk.java.net/browse/JDK-8220448

