### PR TITLE
Update Dockerfile with packages missing for MPS 2022.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
 	build-essential \
 	bison \
 	ca-certificates \
-    cppcheck \
+        cppcheck \
 	curl \
 	flex \
 	g++ \
@@ -15,9 +15,11 @@ RUN apt-get update && apt-get install -y \
 	gdb \
 	git \
 	lcov \
+        libgbm-dev \
 	libz-dev \
 	libwww-perl \
 	libxerces-c-dev \
+        libxss1 \
 	make \
 	nsis \
 	g++-multilib \


### PR DESCRIPTION
The packages had to be added because JBR17 loads libraries `libgbm.so.1` and `libxkbcommon.so.0` that the packages include.